### PR TITLE
Update sortBy in request url string

### DIFF
--- a/MMM-PNews.js
+++ b/MMM-PNews.js
@@ -36,7 +36,7 @@
           var self = this;
           moment.locale(config.language);
           this.today = "";
-          this.url = "https://newsapi.org/v1/articles?source=" + this.config.newsSource + "&sortBy=latest&apiKey=";
+          this.url = "https://newsapi.org/v1/articles?source=" + this.config.newsSource + "&sortBy=top&apiKey=";
           this.news = {};
           this.aItem = 0;
           this.rotate = null;


### PR DESCRIPTION
From https://newsapi.org/google-news-api:
https://newsapi.org/v1/articles?source=google-news&sortBy=top&apiKey=...

using latest returns no news items, updating to top fixes the issue.